### PR TITLE
Add source code window button to TinyMceWidget

### DIFF
--- a/tinymezzce4/static/tinymezzce4/js/tinymce_setup.js
+++ b/tinymezzce4/static/tinymezzce4/js/tinymce_setup.js
@@ -31,7 +31,7 @@ jQuery(function($) {
             menubar: false,
             toolbar: ("insertfile undo redo | styleselect | bold italic | " +
                       "alignleft aligncenter alignright alignjustify | " +
-                      "bullist numlist outdent indent | link image"),
+                      "bullist numlist outdent indent | link image | code"),
             file_browser_callback: custom_file_browser,
             content_css: window.__tinymce_css
         });


### PR DESCRIPTION
This adds a source code window button to the TinyMCE4-enabled
TinyMceWidget in order to achieve functional parity with the
TinyMCE3 TinyMceWidget currently in Mezzanine.
